### PR TITLE
Removed 'weather' naming from sources not related to tests

### DIFF
--- a/src/main/java/de/codecentric/cxf/logging/BaseLogger.java
+++ b/src/main/java/de/codecentric/cxf/logging/BaseLogger.java
@@ -83,8 +83,8 @@ public class BaseLogger {
         logError("901", "An Error accured in backend-processing: {}", cause.getMessage());
     }
     
-    public void failedToBuildWeatherServiceCompliantSoapFaultDetails(Throwable cause) {
-        logError("902", "Failed to build Weather-compliant SoapFault-details: {}\nStacktrace: {}", cause.getMessage(), cause.getStackTrace());
+    public void failedToBuildServiceCompliantSoapFaultDetails(Throwable cause) {
+        logError("902", "Failed to build service-compliant SoapFault-details: {}\nStacktrace: {}", cause.getMessage(), cause.getStackTrace());
     }   
     
     public void schemaValidationError(FaultType error, String faultMessage) {

--- a/src/main/java/de/codecentric/cxf/xmlvalidation/SoapFaultBuilder.java
+++ b/src/main/java/de/codecentric/cxf/xmlvalidation/SoapFaultBuilder.java
@@ -53,7 +53,7 @@ public class SoapFaultBuilder {
 	    	// we append it to a new Element, which then gets deleted again
 	    	exceptionElementAppended = XmlUtils.appendAsChildElement2NewElement(faultDetailAsDoc);
 		} catch (Exception exception) {
-			LOG.failedToBuildWeatherServiceCompliantSoapFaultDetails(exception);
+			LOG.failedToBuildServiceCompliantSoapFaultDetails(exception);
 			// We don´t want an Exception thrown here
 		}
 		return exceptionElementAppended;


### PR DESCRIPTION
Hi,
This PR just renames one logging method from ```src/main```, which has ```Weather``` in the name and in the log message itself. The ```Weather``` naming comes from tests and probably shouldn't be used in the production code. 

Best regards,
Tomas