### PR TITLE
#20 Setting the endpoint URL via  soap.service.publishedEndpointUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ Because there is (& sadly will be) [no @ConditionalOnMissingProperty in Spring B
 
 To get the desired deactivation flag nevertheless, we need to use the [@ConditionalOnProperty](http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/condition/ConditionalOnProperty.html) in an interesting way :) With the usage of `matchIfMissing = true` and `name = "endpoint.autoinit"` the autoinitialization feature is activated in situations, where the property is missing or is set to `true`. Only, if `endpoint.autoinit=false` the feature is disabled (which is quite ok in our use-case).
 
+###### Setting the URL of the endpoint
+
+You can manually specify the url of the Service Endpoint using the spring property: `soap.service.publishedEndpointUrl`. This can be handy if your application is behind a reverse proxy and the resulting WSDLs don't reflect that.
+
 # Known limitations
 
 ### Using devtools with mvn spring-boot:run

--- a/src/main/java/de/codecentric/cxf/configuration/CxfAutoConfiguration.java
+++ b/src/main/java/de/codecentric/cxf/configuration/CxfAutoConfiguration.java
@@ -45,6 +45,9 @@ public class CxfAutoConfiguration {
     @Value("${soap.service.base.url:/soap-api}")
     private String baseUrl;
 
+    @Value("${soap.service.publishedEndpointUrl:NOT_SET}")
+    private String publishedEndpointUrl;
+
     @Value("${cxf.servicelist.title:CXF SpringBoot Starter - service list}")
     private String serviceListTitle;
 
@@ -120,6 +123,9 @@ public class CxfAutoConfiguration {
         // Also the WSDLLocation must be set
         endpoint.setServiceName(webServiceClient().getServiceName());
         endpoint.setWsdlLocation(webServiceClient().getWSDLDocumentLocation().toString());
+        if(!publishedEndpointUrl.equals("NOT_SET")){
+            endpoint.setPublishedEndpointUrl(publishedEndpointUrl);
+        }
         // publish the Service under it´s name mentioned in the WSDL inside name attribute (example: <wsdl:service name="Weather">)
         endpoint.publish(serviceUrlEnding());
         return endpoint;


### PR DESCRIPTION
This property can be used in case the service is deployed behind a reverse proxy.