### PR TITLE
Constructor autowiring (#56)

### DIFF
--- a/cxf-spring-boot-starter-samples/pom.xml
+++ b/cxf-spring-boot-starter-samples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.codecentric</groupId>
 		<artifactId>cxf-spring-boot-starter-reactor</artifactId>
-		<version>2.3.1-jaxb-jaxws-3.0.0-M4</version>
+		<version>2.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>cxf-spring-boot-starter-samples</artifactId>
 

--- a/cxf-spring-boot-starter/pom.xml
+++ b/cxf-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.codecentric</groupId>
 		<artifactId>cxf-spring-boot-starter-reactor</artifactId>
-		<version>2.3.1-jaxb-jaxws-3.0.0-M4</version>
+		<version>2.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>cxf-spring-boot-starter</artifactId>
 	<description>Boot starter for SOAP-Webservices with Apache CXF using JAX-WS &amp; JAXB with Annotations only</description>

--- a/cxf-spring-boot-starter/src/main/java/de/codecentric/cxf/configuration/CxfAutoConfiguration.java
+++ b/cxf-spring-boot-starter/src/main/java/de/codecentric/cxf/configuration/CxfAutoConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -58,13 +59,13 @@ public class CxfAutoConfiguration {
 
 
     @Bean
-    public WebServiceAutoDetector webServiceAutoDetector() throws BootStarterCxfException {
-        return new WebServiceAutoDetector(new WebServiceScanner());
+    public WebServiceAutoDetector webServiceAutoDetector(ApplicationContext applicationContext) throws BootStarterCxfException {
+        return new WebServiceAutoDetector(new WebServiceScanner(), applicationContext);
     }
 
     @PostConstruct
     public void setUp() throws BootStarterCxfException {
-        webServiceClient = webServiceAutoDetector().searchAndInstantiateWebServiceClient();
+        webServiceClient = webServiceAutoDetector(null).searchAndInstantiateWebServiceClient();
         serviceUrlEnding = "/" + webServiceClient().getServiceName().getLocalPart();
     }
 
@@ -106,7 +107,7 @@ public class CxfAutoConfiguration {
     @ConditionalOnProperty(name = "endpoint.autoinit", matchIfMissing = true)
     public Object seiImplementation() throws BootStarterCxfException {
         if(seiImplementation == null) {
-            seiImplementation = webServiceAutoDetector().searchAndInstantiateSeiImplementation();
+            seiImplementation = webServiceAutoDetector(null).searchAndInstantiateSeiImplementation();
         }
         return seiImplementation;
     }

--- a/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/TestServiceEndpoint.java
+++ b/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/TestServiceEndpoint.java
@@ -12,6 +12,8 @@ import de.codecentric.namespace.weatherservice.general.WeatherInformationReturn;
 import de.codecentric.namespace.weatherservice.general.WeatherReturn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -24,8 +26,17 @@ public class TestServiceEndpoint implements WeatherService {
     private static final Logger LOG = LoggerFactory.getLogger(TestServiceEndpoint.class);
     private static de.codecentric.namespace.weatherservice.general.ObjectFactory objectFactoryGeneral = new de.codecentric.namespace.weatherservice.general.ObjectFactory();
     private static de.codecentric.namespace.weatherservice.datatypes.ObjectFactory objectFactoryDatatypes = new de.codecentric.namespace.weatherservice.datatypes.ObjectFactory();
+    private final Object injectedBean;
 
-    
+    @Autowired
+    public TestServiceEndpoint(ApplicationContext context) {
+        this.injectedBean = context;
+    }
+
+    public Object getInjectedBean() {
+        return injectedBean;
+    }
+
     @Override
     public WeatherInformationReturn getWeatherInformation(String zip)
             throws WeatherException {

--- a/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/autodetection/WebServiceAutoDetectorTest.java
+++ b/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/autodetection/WebServiceAutoDetectorTest.java
@@ -11,6 +11,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
 
 import javax.xml.namespace.QName;
 import javax.xml.ws.Service;
@@ -51,7 +53,8 @@ public class WebServiceAutoDetectorTest {
 
         WebServiceScanner scannerMock = mock(WebServiceScanner.class);
         when(scannerMock.scanForClassWithAnnotationAndIsAnInterface(SEI_ANNOTATION, seiAndWebServiceClientPackageName)).thenReturn(WEATHER_SERVICE_ENDPOINT_INTERFACE);
-        WebServiceAutoDetector webServiceAutoDetector = new WebServiceAutoDetector(scannerMock);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        WebServiceAutoDetector webServiceAutoDetector = new WebServiceAutoDetector(scannerMock, applicationContext);
 
         Class serviceEndpointInterface = webServiceAutoDetector.searchServiceEndpointInterface();
 
@@ -64,7 +67,11 @@ public class WebServiceAutoDetectorTest {
 
         WebServiceScanner scannerMock = mock(WebServiceScanner.class);
         when(scannerMock.scanForClassWhichImplementsAndPickFirst(WEATHER_SERVICE_ENDPOINT_INTERFACE, seiImplementationPackageName)).thenReturn(WEATHER_SEI_IMPLEMENTING_CLASS);
-        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        AutowireCapableBeanFactory beanFactory = mock(AutowireCapableBeanFactory.class);
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(beanFactory);
+        when(beanFactory.createBean(TestServiceEndpoint.class)).thenReturn(new TestServiceEndpoint(null));
+        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock, applicationContext);
 
         WeatherService weatherServiceEndpointImpl = autoDetector.searchAndInstantiateSeiImplementation(WEATHER_SERVICE_ENDPOINT_INTERFACE);
 
@@ -77,7 +84,11 @@ public class WebServiceAutoDetectorTest {
 
         WebServiceScanner scannerMock = mock(WebServiceScanner.class);
         when(scannerMock.scanForClassWithAnnotationAndPickTheFirstOneFound(WEB_SERVICE_CLIENT_ANNOTATION, seiAndWebServiceClientPackageName)).thenReturn(WEATHER_WEBSERVICE_CLIENT);
-        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        AutowireCapableBeanFactory beanFactory = mock(AutowireCapableBeanFactory.class);
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(beanFactory);
+        when(beanFactory.createBean(Weather.class)).thenReturn(new Weather());
+        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock, applicationContext);
 
         Service webServiceClient = autoDetector.searchAndInstantiateWebServiceClient();
 
@@ -92,7 +103,8 @@ public class WebServiceAutoDetectorTest {
 
         WebServiceScanner scannerMock = mock(WebServiceScanner.class);
         when(scannerMock.scanForClassWhichImplementsAndPickFirst(WEATHER_SERVICE_ENDPOINT_INTERFACE, seiImplementationPackageName)).thenThrow(STARTER_EXCEPTION_NO_CLASS_FOUND);
-        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock, applicationContext);
 
         autoDetector.searchAndInstantiateSeiImplementation(WEATHER_SERVICE_ENDPOINT_INTERFACE);
     }
@@ -102,7 +114,8 @@ public class WebServiceAutoDetectorTest {
 
         WebServiceScanner scannerMock = mock(WebServiceScanner.class);
         when(scannerMock.scanForClassWithAnnotationAndPickTheFirstOneFound(WEB_SERVICE_CLIENT_ANNOTATION, seiAndWebServiceClientPackageName)).thenThrow(STARTER_EXCEPTION_NO_CLASS_FOUND);
-        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock, applicationContext);
 
         autoDetector.searchAndInstantiateWebServiceClient();
     }
@@ -113,7 +126,8 @@ public class WebServiceAutoDetectorTest {
         WebServiceScanner scannerMock = mock(WebServiceScanner.class);
         when(scannerMock.scanForClassNamesWithAnnotation(SEI_ANNOTATION, seiAndWebServiceClientPackageName)).thenThrow(STARTER_EXCEPTION_NO_CLASS_FOUND);
         when(scannerMock.scanForClassWithAnnotationAndIsAnInterface(SEI_ANNOTATION, seiAndWebServiceClientPackageName)).thenCallRealMethod();
-        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        WebServiceAutoDetector autoDetector = new WebServiceAutoDetector(scannerMock, applicationContext);
 
         autoDetector.searchServiceEndpointInterface();
     }

--- a/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/endpoint/WeatherServiceEndpointSystemTest.java
+++ b/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/endpoint/WeatherServiceEndpointSystemTest.java
@@ -2,6 +2,7 @@ package de.codecentric.cxf.endpoint;
 
 
 import de.codecentric.cxf.TestApplication;
+import de.codecentric.cxf.TestServiceEndpoint;
 import de.codecentric.cxf.common.BootStarterCxfException;
 import de.codecentric.cxf.common.XmlUtils;
 import de.codecentric.namespace.weatherservice.WeatherException;
@@ -33,6 +34,9 @@ public class WeatherServiceEndpointSystemTest {
 	@Autowired
 	private WeatherService weatherServiceClient;
 
+	@Autowired
+	private TestServiceEndpoint testServiceEndpoint;
+
 	@Value(value="classpath:requests/GetCityForecastByZIPTest.xml")
 	private Resource GetCityForecastByZIPTestXml;
 	
@@ -49,5 +53,10 @@ public class WeatherServiceEndpointSystemTest {
 		assertNotNull(forecastReturn);
 		assertEquals("Weimar", forecastReturn.getCity());
 		assertEquals("22%", forecastReturn.getForecastResult().getForecast().get(0).getProbabilityOfPrecipiation().getDaytime());
+	}
+
+	@Test
+	public void isEndpointCorrectlyAutowired() {
+		assertNotNull(testServiceEndpoint.getInjectedBean());
 	}
 }


### PR DESCRIPTION
The main change is that endpoints are instantiated using `applicationContext.getAutowireCapableBeanFactory().createBean(clazz)` rather than using reflection directly.

Actual autowiring is tested in `WeatherServiceEndpointSystemTest.java`.

Note that endpoints don't necessarily need the `@Autowired` annotation, Spring will also manage non-annotated constructors as long as the dependencies exist.