### PR TITLE
Update spring boot

### DIFF
--- a/cxf-spring-boot-starter/pom.xml
+++ b/cxf-spring-boot-starter/pom.xml
@@ -18,7 +18,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- Project dependencies -->
-		<spring.boot.version>2.5.12</spring.boot.version>
+		<spring.boot.version>2.7.5</spring.boot.version>
 		<cxf-spring-boot-starter-maven-plugin.version>2.3.0.RELEASE</cxf-spring-boot-starter-maven-plugin.version>
 		<cxf.version>3.5.4</cxf.version>
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
@@ -27,7 +27,7 @@
 		<camunda.version>7.18.0</camunda.version>
 		<logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
 		<commons-io.version>2.11.0</commons-io.version>
-		<spring.cloud.sleuth.version>3.0.4</spring.cloud.sleuth.version>
+		<spring.cloud.sleuth.version>3.1.5</spring.cloud.sleuth.version>
 		<system-stubs-jupiter.version>2.0.1</system-stubs-jupiter.version>
 
 		<!-- Analysis Tools for CI -->

--- a/cxf-spring-boot-starter/src/main/java/de/codecentric/cxf/configuration/CxfAutoConfiguration.java
+++ b/cxf-spring-boot-starter/src/main/java/de/codecentric/cxf/configuration/CxfAutoConfiguration.java
@@ -53,20 +53,12 @@ public class CxfAutoConfiguration {
     @Value("${cxf.servicelist.title:CXF SpringBoot Starter - service list}")
     private String serviceListTitle;
 
-    private String serviceUrlEnding = "";
+    private String serviceUrlEnding = null;
     private Object seiImplementation;
-    private Service webServiceClient;
-
 
     @Bean
     public WebServiceAutoDetector webServiceAutoDetector(ApplicationContext applicationContext) throws BootStarterCxfException {
         return new WebServiceAutoDetector(new WebServiceScanner(), applicationContext);
-    }
-
-    @PostConstruct
-    public void setUp() throws BootStarterCxfException {
-        webServiceClient = webServiceAutoDetector(null).searchAndInstantiateWebServiceClient();
-        serviceUrlEnding = "/" + webServiceClient().getServiceName().getLocalPart();
     }
 
     /**
@@ -126,7 +118,7 @@ public class CxfAutoConfiguration {
         endpoint.setServiceName(webServiceClient().getServiceName());
         endpoint.setWsdlLocation(webServiceClient().getWSDLDocumentLocation().toString());
         if (publishedEndpointUrl.equals("NOT_SET")) {
-            endpoint.setPublishedEndpointUrl(webServiceClient.getServiceName().getLocalPart());
+            endpoint.setPublishedEndpointUrl(webServiceClient().getServiceName().getLocalPart());
         } else {
             endpoint.setPublishedEndpointUrl(publishedEndpointUrl);
         }
@@ -138,7 +130,7 @@ public class CxfAutoConfiguration {
     @Bean
     public Service webServiceClient() throws BootStarterCxfException {
         // Needed for correct ServiceName & WSDLLocation to publish contract first incl. original WSDL
-        return webServiceClient;
+        return webServiceAutoDetector(null).searchAndInstantiateWebServiceClient();
     }
     
     /**
@@ -152,7 +144,10 @@ public class CxfAutoConfiguration {
      * @return the concrete Service URL-ending, where the WebService is configured according to your WSDL´s Service Name
      * (e.g. &quot;/Weather&quot; when there is this inside your WSDL: &lt;wsdl:service name=&quot;Weather&quot;&gt;)
      */
-    public String serviceUrlEnding() {
+    public String serviceUrlEnding() throws BootStarterCxfException {
+        if (serviceUrlEnding == null) {
+            serviceUrlEnding = "/" + webServiceClient().getServiceName().getLocalPart();
+        }
         return serviceUrlEnding;
     }
 
@@ -161,7 +156,7 @@ public class CxfAutoConfiguration {
      * the concrete Service URL-ending, where the WebService is configured according to your WSDL´s Service Name
      * (e.g. &quot;/Weather&quot; when there is this inside your WSDL: &lt;wsdl:service name=&quot;Weather&quot;&gt;)
      */
-    public String baseAndServiceEndingUrl() {
+    public String baseAndServiceEndingUrl() throws BootStarterCxfException {
         return baseUrl() + serviceUrlEnding();
     }
     

--- a/cxf-spring-boot-starter/src/main/java/de/codecentric/cxf/configuration/XmlValidationConfiguration.java
+++ b/cxf-spring-boot-starter/src/main/java/de/codecentric/cxf/configuration/XmlValidationConfiguration.java
@@ -30,13 +30,7 @@ public class XmlValidationConfiguration {
 
     @Autowired
     public Endpoint endpoint;
-    
-    @PostConstruct
-    public void configureInterceptor2Endpoint() {    
-        EndpointImpl endpointImpl = (EndpointImpl)endpoint; // we need the implementation here, to configure our Interceptor
-        endpointImpl.getOutFaultInterceptors().add(soapInterceptor());
-    }
-    
+
     @Bean
     public SoapFaultBuilder soapFaultBuilder() {
         return new SoapFaultBuilder();
@@ -46,6 +40,8 @@ public class XmlValidationConfiguration {
     public AbstractSoapInterceptor soapInterceptor() {
         XmlValidationInterceptor xmlValidationInterceptor = new XmlValidationInterceptor();
         xmlValidationInterceptor.setSoapFaultBuilder(soapFaultBuilder());
+        EndpointImpl endpointImpl = (EndpointImpl)endpoint; // we need the implementation here, to configure our Interceptor
+        endpointImpl.getOutFaultInterceptors().add(xmlValidationInterceptor);
         return xmlValidationInterceptor;
     }
 }

--- a/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/TestServiceSystemTestConfiguration.java
+++ b/cxf-spring-boot-starter/src/test/java/de/codecentric/cxf/TestServiceSystemTestConfiguration.java
@@ -18,7 +18,7 @@ public class TestServiceSystemTestConfiguration {
      * CXF JaxWs Client
      */
     @Bean
-    public WeatherService weatherServiceClient() {
+    public WeatherService weatherServiceClient() throws BootStarterCxfException {
         JaxWsProxyFactoryBean jaxWsFactory = new JaxWsProxyFactoryBean();
         jaxWsFactory.setServiceClass(WeatherService.class);
         jaxWsFactory.setAddress(buildUrl());
@@ -31,7 +31,7 @@ public class TestServiceSystemTestConfiguration {
         return new SoapRawClient(buildUrl(), WeatherService.class);
     }
     
-    private String buildUrl() {
+    private String buildUrl() throws BootStarterCxfException {
         // return something like http://localhost:8084/soap-api/WeatherSoapService
         return "http://localhost:8087" + cxfAutoConfiguration.baseAndServiceEndingUrl();
     }


### PR DESCRIPTION
Starting with Spring Boot 2.6 circular references are forbidden by default. @PostConstruct and @Bean can lead to circular reference on Configration class itself, see https://github.com/spring-projects/spring-framework/issues/27876